### PR TITLE
ci: rename platform secrets/variables to P6M_ prefix (YP6M-2549)

### DIFF
--- a/contents/base/{{ project-name }}/.github/workflows/build-branch.yaml
+++ b/contents/base/{{ project-name }}/.github/workflows/build-branch.yaml
@@ -34,8 +34,8 @@ jobs:
       - build-and-release
 
     with:
-      registry: ${{'{'}}{ vars.ARTIFACTORY_HOSTNAME }}
-      image-name: ${{'{'}}{ vars.ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}
+      registry: ${{'{'}}{ vars.P6M_ARTIFACTORY_HOSTNAME }}
+      image-name: ${{'{'}}{ vars.P6M_ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}
       context: "."
       dockerfile: ./Dockerfile
       tags: |
@@ -46,7 +46,7 @@ jobs:
       # linux-arm-runner: ubuntu-24.04-arm-provisioned
 
     secrets:
-      username: ${{'{'}}{ secrets.ARTIFACTORY_USERNAME }}
-      password: ${{'{'}}{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+      username: ${{'{'}}{ secrets.P6M_ARTIFACTORY_USERNAME }}
+      password: ${{'{'}}{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       secrets: |
-        artifactory-token=${{'{'}}{ secrets.ARTIFACTORY_TOKEN }}
+        artifactory-token=${{'{'}}{ secrets.P6M_ARTIFACTORY_TOKEN }}

--- a/contents/base/{{ project-name }}/.github/workflows/build-main.yaml
+++ b/contents/base/{{ project-name }}/.github/workflows/build-main.yaml
@@ -40,8 +40,8 @@ jobs:
       - build-and-release
 
     with:
-      registry: ${{'{'}}{ vars.ARTIFACTORY_HOSTNAME }}
-      image-name: ${{'{'}}{ vars.ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}-server
+      registry: ${{'{'}}{ vars.P6M_ARTIFACTORY_HOSTNAME }}
+      image-name: ${{'{'}}{ vars.P6M_ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}-server
       context: "."
       dockerfile: ./Dockerfile
       tags: |
@@ -53,10 +53,10 @@ jobs:
       # linux-arm-runner: ubuntu-24.04-arm-provisioned
 
     secrets:
-      username: ${{'{'}}{ secrets.ARTIFACTORY_USERNAME }}
-      password: ${{'{'}}{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+      username: ${{'{'}}{ secrets.P6M_ARTIFACTORY_USERNAME }}
+      password: ${{'{'}}{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       secrets: |
-        artifactory-token=${{'{'}}{ secrets.ARTIFACTORY_TOKEN }}
+        artifactory-token=${{'{'}}{ secrets.P6M_ARTIFACTORY_TOKEN }}
 
   trigger-cd:
     name: Trigger CD
@@ -78,8 +78,8 @@ jobs:
           directory-name: ${{'{'}}{ env.GITHUB_REPOSITORY_BASENAME }}
           environment: "dev"
           digest: ${{'{'}}{ needs.docker-build.outputs.digest }}
-          update-manifest-token: ${{'{'}}{ secrets.UPDATE_MANIFEST_TOKEN }}
-          platform-dispatch-url: ${{'{'}}{ vars.PLATFORM_DISPATCH_URL }}
+          update-manifest-token: ${{'{'}}{ secrets.P6M_UPDATE_MANIFEST_TOKEN }}
+          platform-dispatch-url: ${{'{'}}{ vars.P6M_PLATFORM_DISPATCH_URL }}
 
   create-release:
     runs-on: ubuntu-latest

--- a/contents/base/{{ project-name }}/.github/workflows/cut-tag.yaml
+++ b/contents/base/{{ project-name }}/.github/workflows/cut-tag.yaml
@@ -51,8 +51,8 @@ jobs:
 
     with:
       github_ref: ${{'{'}}{ needs.release.outputs.tag }}
-      registry: ${{'{'}}{ vars.ARTIFACTORY_HOSTNAME }}
-      image-name: ${{'{'}}{ vars.ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}-server
+      registry: ${{'{'}}{ vars.P6M_ARTIFACTORY_HOSTNAME }}
+      image-name: ${{'{'}}{ vars.P6M_ARTIFACTORY_PROJECT }}-docker/applications/{{ project-name }}-server
       context: "."
       dockerfile: ./Dockerfile
       tags: |
@@ -64,10 +64,10 @@ jobs:
       # linux-arm-runner: ubuntu-24.04-arm-provisioned
 
     secrets:
-      username: ${{'{'}}{ secrets.ARTIFACTORY_USERNAME }}
-      password: ${{'{'}}{ secrets.ARTIFACTORY_IDENTITY_TOKEN }}
+      username: ${{'{'}}{ secrets.P6M_ARTIFACTORY_USERNAME }}
+      password: ${{'{'}}{ secrets.P6M_ARTIFACTORY_IDENTITY_TOKEN }}
       secrets: |
-        artifactory-token=${{'{'}}{ secrets.ARTIFACTORY_TOKEN }}
+        artifactory-token=${{'{'}}{ secrets.P6M_ARTIFACTORY_TOKEN }}
 
   create-release:
     runs-on: ubuntu-latest

--- a/contents/base/{{ project-name }}/.github/workflows/promote.yaml
+++ b/contents/base/{{ project-name }}/.github/workflows/promote.yaml
@@ -46,8 +46,8 @@ jobs:
           directory-name: ${{'{'}}{ env.GITHUB_REPOSITORY_BASENAME }}
           environment: ${{'{'}}{ inputs.environment }}
           digest: ${{'{'}}{ env.DIGEST_TO_PROMOTE }}
-          update-manifest-token: ${{'{'}}{ secrets.UPDATE_MANIFEST_TOKEN }}
-          platform-dispatch-url: ${{'{'}}{ vars.PLATFORM_DISPATCH_URL }}
+          update-manifest-token: ${{'{'}}{ secrets.P6M_UPDATE_MANIFEST_TOKEN }}
+          platform-dispatch-url: ${{'{'}}{ vars.P6M_PLATFORM_DISPATCH_URL }}
 
       - uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Renames platform-managed GitHub Actions secret/variable references to their `P6M_`-prefixed twins across the archetype's own workflows and templated content. Part of YP6M-2549.

⚠️ Hold merge until dual-emit is verified for p6m-archetypes and the target consumer orgs.